### PR TITLE
fix approve tx trying to increase allowance above uint128 limit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -406,7 +406,7 @@ export class Zilswap {
             {
               vname: 'amount',
               type: 'Uint128',
-              value: new BigNumber(2).pow(128).minus(1).toString(),
+              value: new BigNumber(2).pow(128).minus(1).minus(allowance).toString(),
             },
           ],
           {


### PR DESCRIPTION
...for existing users who did approve tokens before, we will need to fetch their current approval amount for that particular token for the ZilSwap contract, and then tabulate:
(2**128 - existing_amount - 1)

Else, there will be this [error of overflow](https://viewblock.io/zilliqa/tx/c63be0a2074032318090a28c12381402f3d5cad9f8008ffe7d3b447a5ffd5869?network=testnet)