### PR TITLE
Support mixed case tokens - getTokenAddresses()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1282,7 +1282,7 @@ export class Zilswap {
       address = id
       hash = fromBech32Address(address).toLowerCase()
     } else {
-      address = this.tokens[id.toUpperCase()]
+      address = this.tokens[id]
       hash = fromBech32Address(address).toLowerCase()
     }
 


### PR DESCRIPTION
The introduction of mixed case ZIL tokens (gZIL) causes getTokenAddresses lookup to fail.

Removed the toUppercase() conversion