### PR TITLE
Load tokens from ZilStream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zilswap-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Zilswap TypeScript SDK",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ import { Mutex } from 'async-mutex'
 import { APIS, WSS, CONTRACTS, CHAIN_VERSIONS, BASIS, Network, ZIL_HASH } from './constants'
 import { unitlessBigNumber, toPositiveQa, isLocalStorageAvailable } from './utils'
 import { sendBatchRequest, BatchRequest, BatchResponse } from './batch'
-import { Stream } from 'stream'
 
 BigNumber.config({ EXPONENTIAL_AT: 1e9 }) // never!
 


### PR DESCRIPTION
This changes the source of the tokens from the deprecated zilswap-token-list to ZilStream's tokens.

One caveat:
Because ZilStream doesn't return both mainnet and testnet tokens, and since listed testnet tokens don't seem to be changing, I have included the default testnet list into the code.