### PR TITLE
Remove GetPendingTxn in favor of GetTransactionStatus

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lib/**/*"
   ],
   "dependencies": {
-    "@zilliqa-js/zilliqa": "^1.0.0",
+    "@zilliqa-js/zilliqa": "^2.2.0",
     "async-mutex": "^0.2.2",
     "bignumber.js": "^9.0.0",
     "bn.js": "^5.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1271,8 +1271,9 @@ export class Zilswap {
     try {
       const removeTxs: string[] = []
       const promises = this.observedTxs.map(async (observedTx: ObservedTx) => {
-        const result = await this.zilliqa.blockchain.getPendingTxn(observedTx.hash)
-        if (result && result.confirmed) {
+        const result = await this.zilliqa.blockchain.getTransactionStatus(observedTx.hash)
+        
+        if (result && result.modificationState == 2) {
           // either confirmed or rejected
           const confirmedTxn = await this.zilliqa.blockchain.getTransaction(observedTx.hash)
           const receipt = confirmedTxn.getReceipt()

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,61 +93,61 @@
   dependencies:
     "@types/node" "*"
 
-"@zilliqa-js/account@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/account/-/account-1.0.0.tgz#636c1847487200bd7fb515e02de2f4de11bfb6fe"
-  integrity sha512-pu9g3PB1Q5UtJiGuAQ0G//AHp697QdE6nuceN73Jks2NKfY32pYba0lRg5mcyP777YWW38wiBcT4E5O2pU+94Q==
+"@zilliqa-js/account@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/account/-/account-2.2.1.tgz#f12c2ef5219a899bd5c64077fbf0a4b677189ce4"
+  integrity sha512-egq/S1KyrH8qlmMBKHaAmLU/RLl66JYPDEPe3n97NP/yvrbPTt7sEfgfOwL1IO0hIBLlJPQYIdKtlYHzn22BLw==
   dependencies:
     "@types/bip39" "^2.4.0"
     "@types/hdkey" "^0.7.0"
-    "@zilliqa-js/core" "1.0.0"
-    "@zilliqa-js/crypto" "1.0.0"
-    "@zilliqa-js/proto" "0.11.1"
-    "@zilliqa-js/util" "0.11.1"
+    "@zilliqa-js/core" "2.2.1"
+    "@zilliqa-js/crypto" "2.2.1"
+    "@zilliqa-js/proto" "2.2.0"
+    "@zilliqa-js/util" "2.2.0"
     bip39 "^2.5.0"
     hdkey "^1.1.0"
 
-"@zilliqa-js/blockchain@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/blockchain/-/blockchain-1.0.0.tgz#67dae6d0b48a58b2a60fe129c00a1984c3d6923d"
-  integrity sha512-M7FI9IkX/e1DayQjzDFLuivtw51pEXekj66G9MvIcm9wYDICWGD05ucSGCHuYGquj4oi2n+dFDxOH0VPSJrcLQ==
+"@zilliqa-js/blockchain@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/blockchain/-/blockchain-2.2.1.tgz#bed1811bc5af4ce8cd7f32620a1aa4e368cad975"
+  integrity sha512-GiUzRAceOgsF9Nk/LzdionZt6QlLMDH72Z4/qt1SQY2vdK0rz9fbjBtQbZjVjfvwvGSjmOBo3KVYPhviJHuGYQ==
   dependencies:
-    "@zilliqa-js/account" "1.0.0"
-    "@zilliqa-js/contract" "1.0.0"
-    "@zilliqa-js/core" "1.0.0"
-    "@zilliqa-js/crypto" "1.0.0"
-    "@zilliqa-js/util" "0.11.1"
+    "@zilliqa-js/account" "2.2.1"
+    "@zilliqa-js/contract" "2.2.1"
+    "@zilliqa-js/core" "2.2.1"
+    "@zilliqa-js/crypto" "2.2.1"
+    "@zilliqa-js/util" "2.2.0"
     utility-types "^3.4.1"
 
-"@zilliqa-js/contract@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/contract/-/contract-1.0.0.tgz#ec0fc9faa7791dc660fb2d23a1c194a74d374d1b"
-  integrity sha512-cwxKi7ZyfTW43JTqDNM86A/cK1y1mTI6iwaDBnGahj8w3kQOGficZr1oc0SOsyHNo5l1ACuywDnLgv7/aPaeJw==
+"@zilliqa-js/contract@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/contract/-/contract-2.2.1.tgz#2b123f0a0ce77f1a20b10a4d2effdffdc260330d"
+  integrity sha512-DmhElqUbgyUNxwKwKSJq6L8WfxOBVrrQ72crHrnubIgnhN3uNRaS9lZ4oAMAi1o6eSYe94GCBHGOZ5imSYxFrg==
   dependencies:
-    "@zilliqa-js/account" "1.0.0"
-    "@zilliqa-js/blockchain" "1.0.0"
-    "@zilliqa-js/core" "1.0.0"
-    "@zilliqa-js/crypto" "1.0.0"
-    "@zilliqa-js/util" "0.11.1"
+    "@zilliqa-js/account" "2.2.1"
+    "@zilliqa-js/blockchain" "2.2.1"
+    "@zilliqa-js/core" "2.2.1"
+    "@zilliqa-js/crypto" "2.2.1"
+    "@zilliqa-js/util" "2.2.0"
     hash.js "^1.1.5"
     utility-types "^2.1.0"
 
-"@zilliqa-js/core@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/core/-/core-1.0.0.tgz#7f7dd0ad5cb95fc69674cd5799e03bdedae80c3a"
-  integrity sha512-qlJP6cX/NJcILU7+N2Uwy3uq2xkk1cEiMhJIf4EM0v7A3YY9icr1Y5oUl4cSexjxnAumH4keJNnv15ArzG4e3Q==
+"@zilliqa-js/core@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/core/-/core-2.2.1.tgz#c151d1e2cd530f8928236d68835f0ff7faa119b1"
+  integrity sha512-dEViTcv54waiDckyWROgBcuwDX8iugSKY/Fooa2RynDGHTlb4XvvAxmShTy4+OF1tldhV86cE9nsDW//ICTZPQ==
   dependencies:
-    "@zilliqa-js/crypto" "1.0.0"
-    "@zilliqa-js/util" "0.11.1"
+    "@zilliqa-js/crypto" "2.2.1"
+    "@zilliqa-js/util" "2.2.0"
     cross-fetch "^2.2.2"
     mitt "^1.1.3"
 
-"@zilliqa-js/crypto@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/crypto/-/crypto-1.0.0.tgz#61cb5b4f4aa48335d93afd1870071a39dcdf80ef"
-  integrity sha512-YFBH2om7p+mgRrGhEcGdbYf/ymA3JL3xXYXySUuXZ63zNiiNbKupPJpDMDSre+dcJImYWD9hMumOkWBtZYP1Fw==
+"@zilliqa-js/crypto@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/crypto/-/crypto-2.2.1.tgz#c1468244f35a9ebf7f0ee27881e0a718c09f8d97"
+  integrity sha512-80fCuf6Bjpci+mmTfBp9r+umhWbxji8WE4Ii8jz1QtszkWBXLUvXhw6xFv0txgt74ZmUj12Ot1MENALAFEJEDg==
   dependencies:
-    "@zilliqa-js/util" "0.11.1"
+    "@zilliqa-js/util" "2.2.0"
     aes-js "^3.1.1"
     bsert "^0.0.4"
     elliptic "^6.5.0"
@@ -155,50 +155,49 @@
     hmac-drbg "^1.0.1"
     pbkdf2 "^3.0.16"
     randombytes "^2.0.6"
+    scrypt-js "^3.0.1"
     scryptsy "^2.1.0"
     sodium-native "^3.2.0"
     uuid "^3.3.2"
-  optionalDependencies:
-    scrypt.js "^0.3.0"
 
-"@zilliqa-js/proto@0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/proto/-/proto-0.11.1.tgz#0738efb976393b5bae6c4b1a66832f3cc3b4b1f3"
-  integrity sha512-8fIXnh4uuoZU7bMCSAMoelGOeEpQlCUtc+e6/g9vjijsA0SoBMOpqfzdZpVvyBkmPqZV+yUCXFGb2HyS3n1dcg==
+"@zilliqa-js/proto@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/proto/-/proto-2.2.0.tgz#c3fea22daf4a8e385e5f239119765a0d60f18df7"
+  integrity sha512-0QPNJdvafT0ItPGrqEff7KMYNCT/DkWCn0/x2/UwVoVANy5BHL3WkwDV3y49KthVwdZUotQVzRaweHTs6PIcuA==
   dependencies:
     protobufjs "^6.8.8"
 
-"@zilliqa-js/subscriptions@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/subscriptions/-/subscriptions-1.0.0.tgz#68b35463e8a31b3e1caacb4b0161d4349092deb1"
-  integrity sha512-b/Wglit8UQ//92fiSpXf5+9kpmnI8ipezu2B1DAornGrG7s0tLojNhRISISZ6nDafZ2Pc5Wb8rWhTW8oLcGHAA==
+"@zilliqa-js/subscriptions@2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/subscriptions/-/subscriptions-2.2.1.tgz#f334ef896521d3b6d5c87507cee5acf6cfeeb6fd"
+  integrity sha512-MIz7i1kRCF7TpDzmpOFOhL13xl2CxCfmzpXvaBF1keGcOrqf8o/rgF7YARZ2H5YXobLlGDP5Gjm2qcShkiYfWw==
   dependencies:
-    "@zilliqa-js/core" "1.0.0"
+    "@zilliqa-js/core" "2.2.1"
     mock-socket "^9.0.2"
     websocket "^1.0.28"
 
-"@zilliqa-js/util@0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/util/-/util-0.11.1.tgz#c4c67703fa144da256ec2c4beb7e295233f9250d"
-  integrity sha512-eD6lgY/8kexbxnlGrhE1+gB9D69+5oVfhdjOc4LNKUKsu9aWfg4AdrEWwgt0wndNbbGQcN8JKzlkCXtjNpsk5A==
+"@zilliqa-js/util@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/util/-/util-2.2.0.tgz#6f64adc5494596c93dd0eff566f830b316eba677"
+  integrity sha512-bzThiraMQKDumhQY0HMsutX28HPgqB+KKqiet8M8QQbCFvQODxAGpuxJX6bZiX+6K6tZUk8yDSW8Ri3dgOdRDg==
   dependencies:
     "@types/bn.js" "^4.11.3"
     "@types/long" "^4.0.0"
     bn.js "^4.11.8"
     long "^4.0.0"
 
-"@zilliqa-js/zilliqa@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@zilliqa-js/zilliqa/-/zilliqa-1.0.0.tgz#e8ccfa3d4a80f6df30501569f60f23976ca42b76"
-  integrity sha512-jLDCh2F075kZOI8HCZGYpRsYTd4Fbb5naOy2y30tpqOqjqImJDShpEPv8hDZhPj3wi6FoHMYM49IeO7XPKDa3Q==
+"@zilliqa-js/zilliqa@^2.2.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@zilliqa-js/zilliqa/-/zilliqa-2.2.1.tgz#7d39c8e8459b050033bd5f77126a9fb0fd59d8f6"
+  integrity sha512-gN3VnuwSvK7SFlzRiXUg18In9rBHn33iZRfmVrggRqTtwG04Dv4AyiCG37+ieNG5hQHI5O+gRrCIPSVG24/n2w==
   dependencies:
-    "@zilliqa-js/account" "1.0.0"
-    "@zilliqa-js/blockchain" "1.0.0"
-    "@zilliqa-js/contract" "1.0.0"
-    "@zilliqa-js/core" "1.0.0"
-    "@zilliqa-js/crypto" "1.0.0"
-    "@zilliqa-js/subscriptions" "1.0.0"
-    "@zilliqa-js/util" "0.11.1"
+    "@zilliqa-js/account" "2.2.1"
+    "@zilliqa-js/blockchain" "2.2.1"
+    "@zilliqa-js/contract" "2.2.1"
+    "@zilliqa-js/core" "2.2.1"
+    "@zilliqa-js/crypto" "2.2.1"
+    "@zilliqa-js/subscriptions" "2.2.1"
+    "@zilliqa-js/util" "2.2.0"
 
 aes-js@^3.1.1:
   version "3.1.2"
@@ -523,7 +522,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-nan@^2.0.8, nan@^2.14.0:
+nan@^2.14.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
@@ -548,7 +547,7 @@ node-gyp-build@^4.2.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
   integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
-pbkdf2@^3.0.16, pbkdf2@^3.0.3, pbkdf2@^3.0.9:
+pbkdf2@^3.0.16, pbkdf2@^3.0.9:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
   integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
@@ -622,28 +621,10 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, 
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-scrypt.js@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/scrypt.js/-/scrypt.js-0.3.0.tgz#6c62d61728ad533c8c376a2e5e3e86d41a95c4c0"
-  integrity sha512-42LTc1nyFsyv/o0gcHtDztrn+aqpkaCNt5Qh7ATBZfhEZU7IC/0oT/qbBH+uRNoAPvs2fwiOId68FDEoSRA8/A==
-  dependencies:
-    scryptsy "^1.2.1"
-  optionalDependencies:
-    scrypt "^6.0.2"
-
-scrypt@^6.0.2:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/scrypt/-/scrypt-6.0.3.tgz#04e014a5682b53fa50c2d5cce167d719c06d870d"
-  integrity sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=
-  dependencies:
-    nan "^2.0.8"
-
-scryptsy@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-1.2.1.tgz#a3225fa4b2524f802700761e2855bdf3b2d92163"
-  integrity sha1-oyJfpLJST4AnAHYeKFW987LZIWM=
-  dependencies:
-    pbkdf2 "^3.0.3"
+scrypt-js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
 scryptsy@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR replaces `GetPendingTxn` with `GetTransactionStatus` because the former got removed from the Zilliqa RPC API causing a UI issue showing the transaction notification as confirming indefinitely.

Because `GetTransactionStatus` was added in V2 of the Zilliqa JS SDK I've updated that library to the latest version.

Instead of checking for confirmation on the pending txn this PR changes to check the `modificationState` on the transaction status. With the `modificationState` at 2 the transaction is processed as either confirmed or rejected. See details here: https://dev.zilliqa.com/docs/apis/api-transaction-get-transaction-status/