### PR TITLE
Add ZILO functionality

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,7 @@ export const CONTRACTS: { [key in Networks]: string } = {
   [Network.TestNet]: 'zil1rf3dm8yykryffr94rlrxfws58earfxzu5lw792',
 }
 
-export enum ILO_STATE {
+export enum ILOState {
   Uninitialized = 'Uninitialized',
   Pending = 'Pending',
   Active = 'Active',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,14 @@ export const CONTRACTS: { [key in Networks]: string } = {
   [Network.TestNet]: 'zil1rf3dm8yykryffr94rlrxfws58earfxzu5lw792',
 }
 
+export enum ILO_STATE {
+  Uninitialized = 'Uninitialized',
+  Pending = 'Pending',
+  Active = 'Active',
+  Failed = 'Failed',
+  Completed = 'Completed',
+}
+
 export const CHAIN_VERSIONS: { [key in Networks]: number } = {
   [Network.MainNet]: bytes.pack(1, 1),
   [Network.TestNet]: bytes.pack(333, 1),

--- a/src/index.ts
+++ b/src/index.ts
@@ -185,6 +185,21 @@ export class Zilswap {
     await this.updateBalanceAndNonce()
   }
 
+  /**
+   * Initializes a new Zilo instance and registers it to the ZilSwap SDK,
+   * subscribing to subsequent state changes in the Zilo instance. You may
+   * optionally pass a state observer to subscribe to state changes of this
+   * particular Zilo instance. 
+   * 
+   * If the Zilo instance is already registered, no new instance will be
+   * created. If a new state observer is provided, it will overwrite the 
+   * existing one.
+   * 
+   * @param address is the Zilo contract address which can be given by
+   * either hash (0x...) or bech32 address (zil...).
+   * @param onStateUpdate is the state observer which triggers when state 
+   * updates
+   */
   public async registerZilo(address: string, onStateUpdate?: Zilo.OnStateUpdate): Promise<Zilo> {
     const byStr20Address = this.parseRecipientAddress(address)
 
@@ -202,6 +217,13 @@ export class Zilswap {
     return zilo;
   }
 
+  /**
+   * Deregisters an existing Zilo instance. Does nothing if provided
+   * address is not already registered.
+   * 
+   * @param address is the Zilo contract address which can be given by
+   * either hash (0x...) or bech32 address (zil...).
+   */
   public deregisterZilo(address: string) {
     const byStr20Address = this.parseRecipientAddress(address)
 
@@ -415,6 +437,7 @@ export class Zilswap {
    * hash (0x...) or bech32 address (zil...).
    * @param amountStrOrBN is the required allowance amount the Zilswap contract requires, below which the
    * `IncreaseAllowance` transition is invoked, as a unitless string or BigNumber.
+   * @param spenderHash (optional) is the spender contract address, defaults to the ZilSwap contract address.
    *
    * @returns an ObservedTx if IncreaseAllowance was called, null if not.
    */
@@ -426,7 +449,7 @@ export class Zilswap {
     // Check logged in
     this.checkAppLoadedWithUser()
 
-    const _spenderHash = spenderHash.toLowerCase()
+    const _spenderHash = this.parseRecipientAddress(spenderHash)
     const token = this.getTokenDetails(tokenID)
     const tokenState = await token.contract.getSubState('allowances', [this.appState!.currentUser!, _spenderHash])
     const allowance = new BigNumber(tokenState?.allowances[this.appState!.currentUser!]?.[_spenderHash] || 0)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { Value } from '@zilliqa-js/contract'
 import { BN, units } from '@zilliqa-js/util'
 import { BigNumber } from 'bignumber.js'
 
@@ -116,3 +117,40 @@ export const isLocalStorageAvailable = () => {
   }
   return _lsAvailable
 }
+
+/**
+ * Converts `Value[]` array to map of string values.
+ * `Value.type` is ignored, all values are returned as string.
+ *
+ *
+ * sample input:
+ * ```javascript
+ *  [{
+ *    name: 'address',
+ *    type: 'ByStr20',
+ *    value: '0xbadbeef',
+ *  }, {
+ *    name: 'balance',
+ *    type: 'UInt28',
+ *    value: '100000000',
+ *  }]
+ * ```
+ *
+ * output:
+ * ```javascript
+ *  {
+ *    address: '0xbadbeef',
+ *    balance: '100000000',
+ *  }
+ * ```
+ *
+ * @param params parameters in `Value[]` array representation
+ * @returns mapped object representation - refer to sample output
+ */
+export const contractInitToMap = (params: Value[]): { [index: string]: any } => {
+  const output: { [index: string]: any } = {}
+  for (const set of params) {
+    output[set.vname] = set.value
+  }
+  return output
+};

--- a/src/zilo.ts
+++ b/src/zilo.ts
@@ -197,14 +197,15 @@ export class Zilo {
   }
 
   /**
- * Contribute to the ilo, may need to increase token allowance before proceeding
- *
- * @param amountToContributeStr is the exact amount of tokens to be received from Zilswap as a unitless string (withoout decimals).
- */
+   * Contribute to the ilo, may need to increase token allowance before proceeding
+   *
+   * @param amountToContributeStr is the exact amount of tokens to be received from Zilswap as a unitless string (withoout decimals).
+   */
   public async contribute(amountToContributeStr: string): Promise<ObservedTx | null> {
+    this.zilswap.checkAppLoadedWithUser()
+
     // Check init
     const amountToContribute = unitlessBigNumber(amountToContributeStr)
-    this.zilswap.checkAppLoadedWithUser()
 
     const contributeTxn = await this.zilswap.callContract(
       this.contract,

--- a/src/zilo.ts
+++ b/src/zilo.ts
@@ -1,0 +1,255 @@
+import { Zilswap, ObservedTx } from "."
+import { Contract, Value } from '@zilliqa-js/contract'
+import { TxReceipt as _TxReceipt } from '@zilliqa-js/account'
+import { BN } from '@zilliqa-js/util'
+import { unitlessBigNumber } from './utils'
+import { ILO_STATE } from './constants'
+import { BigNumber } from 'bignumber.js'
+
+
+export type OnStateUpdate = (appState: ZiloAppState) => void
+
+interface ADTValue {
+  constructor: string
+  argtypes: string[]
+  arguments: Value[]
+}
+
+export type ZiloContractState = {
+  initialized: ADTValue
+  contributions: { [key in string]?: any }
+  total_contributions: string
+}
+
+export type ZiloAppState = {
+  contractState: ZiloContractState
+  state: ILO_STATE
+  claimable: boolean
+  contributed: boolean
+  currentNonce: number | null
+  currentUser: string | null
+  userContribution: string
+  contractInit: ContractInit | null
+}
+
+export type ContractInit = {
+  _scilla_version: string
+  zwap_address: string
+  token_address: string
+  token_amount: string
+  target_zil_amount: string
+  target_zwap_amount: string
+  minimum_zil_amount: string
+  liquidity_zil_amount: string
+  receiver_address: string
+  liquidity_address: string
+  start_block: string
+  end_block: string
+  _creation_block: string
+  _this_address: string
+}
+
+
+export class Zilo {
+
+  private zilswap: Zilswap
+  private contract: Contract
+  private contractHash: string
+  private appState?: ZiloAppState
+
+  private stateObserver: OnStateUpdate | null = null
+
+  constructor(zilswap: Zilswap, contract: Contract) {
+    this.zilswap = zilswap
+    this.contract = contract
+    this.contractHash = contract.address!
+  }
+
+  public async initialize(subscription?: OnStateUpdate) {
+    if (subscription) this.stateObserver = subscription
+    await this.zilswap.addToSubscription(this.contractHash);
+    await this.updateZiloState()
+  }
+
+  public async updateZiloState() {
+    const contractState = (await this.contract.getState()) as ZiloContractState
+    console.log({ contractState })
+    const stateOfContract = await this.checkStatus(contractState)
+
+    const currentUser = this.zilswap.getAppState().currentUser;
+
+    const userContribution = contractState.contributions[currentUser || '']
+    const claimable = stateOfContract === ILO_STATE.Completed && new BigNumber(userContribution).isPositive()
+    const contributed = userContribution > 0
+    let contractInit = this.appState?.contractInit || null
+
+    if (!contractInit) {
+      const init = await this.zilswap.fetchContractInit(this.contract)
+
+      contractInit = {
+        _scilla_version: init.find((e: Value) => e.vname === '_scilla_version').value,
+        zwap_address: init.find((e: Value) => e.vname === 'zwap_address').value,
+        token_address: init.find((e: Value) => e.vname === 'token_address').value,
+        token_amount: init.find((e: Value) => e.vname === 'token_amount').value,
+        target_zil_amount: init.find((e: Value) => e.vname === 'target_zil_amount').value,
+        target_zwap_amount: init.find((e: Value) => e.vname === 'target_zwap_amount').value,
+        minimum_zil_amount: init.find((e: Value) => e.vname === 'minimum_zil_amount').value,
+        liquidity_zil_amount: init.find((e: Value) => e.vname === 'liquidity_zil_amount').value,
+        receiver_address: init.find((e: Value) => e.vname === 'receiver_address').value,
+        liquidity_address: init.find((e: Value) => e.vname === 'liquidity_address').value,
+        start_block: init.find((e: Value) => e.vname === 'start_block').value,
+        end_block: init.find((e: Value) => e.vname === 'end_block').value,
+        _creation_block: init.find((e: Value) => e.vname === '_creation_block').value,
+        _this_address: init.find((e: Value) => e.vname === '_this_address').value,
+      }
+    }
+
+    let newState = {
+      contractState,
+      claimable,
+      contributed,
+      currentNonce: this.appState?.currentNonce || 0,
+      currentUser,
+      state: stateOfContract,
+      userContribution,
+      contractInit,
+    }
+    // Set new state
+    this.appState = newState
+    if (this.stateObserver) {
+      this.stateObserver(newState)
+    }
+  }
+
+  public getZiloState(): ZiloAppState {
+    if (!this.appState) {
+      throw new Error('Zilo app state not loaded, call #initialize first.')
+    }
+    return this.appState
+  }
+
+  /**
+   * Checks the state of the current contract
+   * ILO_STATE.Uninitialized = Contract deployed but not initialized
+   * ILO_STATE.Pending = Contract initialized not stated (current block < start block)
+   * ILO_STATE.Active = Contract started
+   * ILO_STATE.Failed = Contract ended but target amount not reached
+   * ILO_STATE.Completed = Contract ended and target amount fufilled
+   *
+   * @param contractState
+   * @returns returns the current ILO_STATE
+   */
+  private async checkStatus(contractState: ZiloContractState): Promise<ILO_STATE> {
+    const init = await this.zilswap.fetchContractInit(this.contract)
+
+    if (!init || contractState.initialized.constructor !== 'True') {
+      return ILO_STATE.Uninitialized
+    }
+    const currentBlock = this.zilswap.getCurrentBlock();
+    const endBlock = init.find((e: Value) => e.vname === 'end_block').value as number
+    const startBlock = init.find((e: Value) => e.vname === 'start_block').value as number
+    const targetAmount = init.find((e: Value) => e.vname === 'target_zil_amount').value as string
+
+    if (currentBlock < startBlock) {
+      return ILO_STATE.Pending
+    }
+
+    if (currentBlock < endBlock) {
+      return ILO_STATE.Active
+    }
+
+    if (new BigNumber(targetAmount).isGreaterThan(new BigNumber(contractState.total_contributions))) {
+      return ILO_STATE.Failed
+    } else {
+      return ILO_STATE.Completed
+    }
+  }
+
+
+  /**
+ * Execute claim function if user contributed
+ */
+  public async claim(): Promise<ObservedTx | null> {
+    // Check init
+    this.zilswap.checkAppLoadedWithUser()
+
+    // check if current state is claimable
+    if (this.appState?.state !== ILO_STATE.Completed && this.appState?.state !== ILO_STATE.Failed) {
+      throw new Error('Not yet claimable/refundable')
+    }
+
+    // no contributio
+    if (!this.appState.contributed) {
+      throw new Error('User did not contribute')
+    }
+
+    const claimTxn = await this.zilswap.callContract(this.contract, 'Claim', [], { amount: new BN(0), ...this.zilswap.txParams() }, true)
+
+    if (claimTxn.isRejected()) {
+      throw new Error('Claim transaction was rejected.')
+    }
+
+    const deadline = this.zilswap.deadlineBlock()
+
+    const observeTxn = {
+      hash: claimTxn.id!,
+      deadline,
+    }
+    await this.zilswap.observeTx(observeTxn)
+
+    return observeTxn
+  }
+
+  public async complete(): Promise<ObservedTx | null> {
+    this.zilswap.checkAppLoadedWithUser()
+
+    const completeTxn = await this.zilswap.callContract(this.contract, 'Complete', [], { amount: new BN(0), ...this.zilswap.txParams() }, true)
+
+    if (completeTxn.isRejected()) {
+      throw new Error('Complete transaction was rejected.')
+    }
+
+    const deadline = this.zilswap.deadlineBlock()
+
+    const observeTxn = {
+      hash: completeTxn.id!,
+      deadline,
+    }
+    await this.zilswap.observeTx(observeTxn)
+
+    return observeTxn
+  }
+
+  /**
+ * Contribute to the ilo, may need to increase token allowance before proceeding
+ *
+ * @param amountToContributeStr is the exact amount of tokens to be received from Zilswap as a unitless string (withoout decimals).
+ */
+  public async contribute(amountToContributeStr: string): Promise<ObservedTx | null> {
+    // Check init
+    const amountToContribute = unitlessBigNumber(amountToContributeStr)
+    this.zilswap.checkAppLoadedWithUser()
+
+    const contributeTxn = await this.zilswap.callContract(
+      this.contract,
+      'Contribute',
+      [],
+      { amount: new BN(amountToContribute.toString()), ...this.zilswap.txParams() },
+      true
+    )
+
+    if (contributeTxn.isRejected()) {
+      throw new Error('Contribute transaction was rejected.')
+    }
+
+    const deadline = this.zilswap.deadlineBlock()
+
+    const observeTxn = {
+      hash: contributeTxn.id!,
+      deadline,
+    }
+    await this.zilswap.observeTx(observeTxn)
+
+    return observeTxn
+  }
+}

--- a/src/zilo.ts
+++ b/src/zilo.ts
@@ -45,6 +45,27 @@ export type ZiloAppState = {
   contractInit: ZiloContractInit | null
 }
 
+/**
+ * Zilo class to represent an instance of a ZilSwap Initial Launch Offering.
+ * 
+ * Usage:
+ * ```
+ * const zilswap = new Zilswap(Network.TestNet)
+ * await zilswap.initialize()
+ * const zilo = await zilswap.registerZilo(ZILO_ADDRESS, ziloStateObserver)
+ * 
+ * const ziloState = zilo.getZiloState()
+ * 
+ * if (ziloState.state === ILOState.Active) {
+ *    const amount = new BigNumber(1).shiftedBy(ZIL_DECIMALS).toString(10)
+ *    const tx = await zilo.contribute(amount)
+ * 
+ *    console.log("distribute TX sent", tx.hash)
+ * } else {
+ *    console.log("ZILO not yet active")
+ * }
+ * ```
+ */
 export class Zilo {
 
   private zilswap: Zilswap
@@ -250,9 +271,9 @@ export class Zilo {
   }
 
   /**
-   * Contribute to the ilo, may need to increase token allowance before proceeding
+   * Contribute to the ILO, may need to increase token allowance before proceeding
    *
-   * @param amountToContributeStr is the exact amount of tokens to be received from Zilswap as a unitless string (withoout decimals).
+   * @param amountToContributeStr is the exact amount of ZIL to be contribute as a unitless string (without decimals).
    */
   public async contribute(amountToContributeStr: string): Promise<ObservedTx | null> {
     this.zilswap.checkAppLoadedWithUser()


### PR DESCRIPTION
Add Zilo implementation which enables maintaining multiple Zilo instances at the same time.

Significant changes to original SDK:

1. `zilswap.zilliqa` is now `readonly` instead of `private readonly`
2. `zilswap.callContract` is now a `public` function
3. `zilswap.approveTokenTransferIfRequired` takes in a third variable for spender contract hash
4. `zilswap.zilos` added as a map of registered Zilo instances
5. `zilswap.registerZilo` added as entry function to creating new Zilo instances 
6. `zilswap.deregisterZilo` added as exit function to tear down Zilo instances
7. `zilswap.subscribeToAppChanges` updated to tear down previous subscription on entry, and subscribe to additional registered Zilo contracts.

TODOs: 
1. Documentation on Zilo class
2. Update tests

```typescript
const zilswap = new Zilswap(Network.TestNet, provider)
await zilswap.initialize()
const zilo = await zilswap.registerZilo(ZILO_ADDRESS, ziloStateObserver)
 
const ziloState = zilo.getZiloState()

if (ziloState.state === ILOState.Active) {
   const amount = new BigNumber(1).shiftedBy(ZIL_DECIMALS).toString(10)
   const tx = await zilo.contribute(amount)

   console.log("distribute TX sent", tx.hash)
} else {
   console.log("ZILO not yet active")
}

// removed
zilswap.deregisterZilo(ZILO_ADDRESS)
```